### PR TITLE
Fixed Formatting Issue

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -115,7 +115,8 @@ maximum age of a session to one week:
 	session.Options = &sessions.Options{
 		Path:     "/",
 		MaxAge:   86400 * 7,
-		HttpOnly: true}
+		HttpOnly: true,
+	}
 
 Sometimes we may want to change authentication and/or encryption keys without
 breaking existing sessions. The CookieStore supports key rotation, and to use


### PR DESCRIPTION
Go will refuse to compile unless the last key is on the same line as the closing brace:

`non-declaration statement outside function body`.

Additionally, I set the HttpOnly flag on. I think this is a good default for everybody as it increases security and Gorilla's cookies are actually encrypted so JavaScript access is unlikely to be needed.
