### PR TITLE
add postgresql session store link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,5 @@ Other implementations of the sessions.Store interface:
  * [github.com/srinathgs/couchbasestore](https://github.com/srinathgs/couchbasestore) - Couchbase
  * [github.com/hnakamur/gaesessions](https://github.com/hnakamur/gaesessions) - Memcache or GAE
  * [github.com/srinathgs/mysqlstore](https://github.com/srinathgs/mysqlstore) - MySQL
+ * [github.com/antonlindstrom/pgstore](https://github.com/antonlindstrom/pgstore) - PostgreSQL
  * [github.com/boj/redistore](https://github.com/boj/redistore) - Redis


### PR DESCRIPTION
I implemented a session store backend using PostgreSQL, thought I'd share with the other stores here.

Thanks!
