### PR TITLE
Added note about calling save before writing to response.

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -56,6 +56,9 @@ is to wrap the top-level mux when calling http.ListenAndServe:
 
 The ClearHandler function is provided by the gorilla/context package.
 
+Also: Call Save before writing to the response, otherwise the session
+cookie will not be sent to the client.
+
 That's all you need to know for the basic usage. Let's take a look at other
 options, starting with flash messages.
 
@@ -69,12 +72,10 @@ flashes, call session.Flashes(). Here is an example:
 		session, _ := store.Get(r, "session-name")
 		// Get the previously flashes, if any.
 		if flashes := session.Flashes(); len(flashes) > 0 {
-			// Just print the flash values.
-			fmt.Fprint(w, "%v", flashes)
+			// Use the flash values.
 		} else {
 			// Set a new flash.
 			session.AddFlash("Hello, flash messages world!")
-			fmt.Fprint(w, "No flashes found.")
 		}
 		session.Save(r, w)
 	}

--- a/doc.go
+++ b/doc.go
@@ -48,6 +48,9 @@ And finally we call session.Save() to save the session in the response.
 Note that in production code, we should check for errors when calling
 session.Save(r, w), and either display an error message or otherwise handle it.
 
+Save must be called before writing to the response, otherwise the session
+cookie will not be sent to the client.
+
 Important Note: If you aren't using gorilla/mux, you need to wrap your handlers
 with context.ClearHandler as or else you will leak memory! An easy way to do this
 is to wrap the top-level mux when calling http.ListenAndServe:
@@ -55,9 +58,6 @@ is to wrap the top-level mux when calling http.ListenAndServe:
     http.ListenAndServe(":8080", context.ClearHandler(http.DefaultServeMux))
 
 The ClearHandler function is provided by the gorilla/context package.
-
-Also: Call Save before writing to the response, otherwise the session
-cookie will not be sent to the client.
 
 That's all you need to know for the basic usage. Let's take a look at other
 options, starting with flash messages.


### PR DESCRIPTION
Also removed calls to fmt.Fprintf in AddFlash example.  If a user
follows the old example then the session won't be stored.

See: https://github.com/gorilla/sessions/issues/39