### PR TITLE
Provide method to set MaxAge on underlying cookies.

### DIFF
--- a/store.go
+++ b/store.go
@@ -51,13 +51,16 @@ type Store interface {
 // Use the convenience function securecookie.GenerateRandomKey() to create
 // strong keys.
 func NewCookieStore(keyPairs ...[]byte) *CookieStore {
-	return &CookieStore{
+	cs := &CookieStore{
 		Codecs: securecookie.CodecsFromPairs(keyPairs...),
 		Options: &Options{
 			Path:   "/",
 			MaxAge: 86400 * 30,
 		},
 	}
+
+	cs.MaxAge(cs.Options.MaxAge)
+	return cs
 }
 
 // CookieStore stores sessions using secure cookies.
@@ -110,6 +113,20 @@ func (s *CookieStore) Save(r *http.Request, w http.ResponseWriter,
 	return nil
 }
 
+// MaxAge sets the maximum age for the store and the underlying cookie
+// implementation.  Individual sessions can be deleted by setting Options.MaxAge
+// = -1 for that session.
+func (s *CookieStore) MaxAge(age int) {
+	s.Options.MaxAge = age
+
+	// Set the maxAge for each securecookie instance.
+	for _, codec := range s.Codecs {
+		if sc, ok := codec.(*securecookie.SecureCookie); ok {
+			sc.MaxAge(age)
+		}
+	}
+}
+
 // FilesystemStore ------------------------------------------------------------
 
 var fileMutex sync.RWMutex
@@ -124,7 +141,7 @@ func NewFilesystemStore(path string, keyPairs ...[]byte) *FilesystemStore {
 	if path == "" {
 		path = os.TempDir()
 	}
-	return &FilesystemStore{
+	fs := &FilesystemStore{
 		Codecs: securecookie.CodecsFromPairs(keyPairs...),
 		Options: &Options{
 			Path:   "/",
@@ -132,6 +149,9 @@ func NewFilesystemStore(path string, keyPairs ...[]byte) *FilesystemStore {
 		},
 		path: path,
 	}
+
+	fs.MaxAge(fs.Options.MaxAge)
+	return fs
 }
 
 // FilesystemStore stores sessions in the filesystem.
@@ -204,6 +224,20 @@ func (s *FilesystemStore) Save(r *http.Request, w http.ResponseWriter,
 	}
 	http.SetCookie(w, NewCookie(session.Name(), encoded, session.Options))
 	return nil
+}
+
+// MaxAge sets the maximum age for the store and the underlying cookie
+// implementation.  Individual sessions can be deleted by setting Options.MaxAge
+// = -1 for that session.
+func (s *FilesystemStore) MaxAge(age int) {
+	s.Options.MaxAge = age
+
+	// Set the maxAge for each securecookie instance.
+	for _, codec := range s.Codecs {
+		if sc, ok := codec.(*securecookie.SecureCookie); ok {
+			sc.MaxAge(age)
+		}
+	}
 }
 
 // save writes encoded session.Values to a file.

--- a/store.go
+++ b/store.go
@@ -114,7 +114,7 @@ func (s *CookieStore) Save(r *http.Request, w http.ResponseWriter,
 }
 
 // MaxAge sets the maximum age for the store and the underlying cookie
-// implementation.  Individual sessions can be deleted by setting Options.MaxAge
+// implementation. Individual sessions can be deleted by setting Options.MaxAge
 // = -1 for that session.
 func (s *CookieStore) MaxAge(age int) {
 	s.Options.MaxAge = age
@@ -227,7 +227,7 @@ func (s *FilesystemStore) Save(r *http.Request, w http.ResponseWriter,
 }
 
 // MaxAge sets the maximum age for the store and the underlying cookie
-// implementation.  Individual sessions can be deleted by setting Options.MaxAge
+// implementation. Individual sessions can be deleted by setting Options.MaxAge
 // = -1 for that session.
 func (s *FilesystemStore) MaxAge(age int) {
 	s.Options.MaxAge = age


### PR DESCRIPTION
Addresses https://github.com/gorilla/sessions/issues/48

Specifically:

- This is easy enough to set on store creation
- However, the current approach to changing the `MaxAge` for a store is by setting the struct value
- We now provide methods on each store to set the `MaxAge` after store creation and on all underlying codecs.
