### PR TITLE
#80 add context_legacy.go and context.go for go 1.7 migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,20 @@ Other implementations of the `sessions.Store` interface:
 * [github.com/michaeljs1990/sqlitestore](https://github.com/michaeljs1990/sqlitestore) - SQLite
 * [github.com/wader/gormstore](https://github.com/wader/gormstore) - GORM (MySQL, PostgreSQL, SQLite)
 
+## Notes
+Note about `GetRegistry` changes: As of Go version 1.7, gorilla/sessions uses the Go standard library's `context` package rather than `gorilla/context`. This required changing `GetRegistry` to return a shallow copy of the http Request. Users of the `sessions.GetRegistry` method who are upgrading to Go 1.7 will need to change calls to `sessions.GetRegistry`. For example, this (Go 1.6 and prior):
+
+```
+reg := sessions.GetRegistry(req)
+```
+
+will need to change to this:
+
+```
+var reg *Registry
+reg, req = sessions.GetRegistry(req)
+```
+
 ## License
 
 BSD licensed. See the LICENSE file for details.

--- a/context.go
+++ b/context.go
@@ -1,0 +1,22 @@
+// +build go1.7
+
+package sessions
+
+import (
+	"context"
+	"net/http"
+)
+
+func contextGet(r *http.Request, key contextKey) interface{} {
+	return r.Context().Value(key)
+}
+
+func contextSave(r *http.Request, key contextKey, val interface{}) *http.Request {
+	ctx := r.Context()
+	ctx = context.WithValue(ctx, key, val)
+	return r.WithContext(ctx)
+}
+
+func contextClear(r *http.Request) {
+	// no-op for go1.7+
+}

--- a/context_legacy.go
+++ b/context_legacy.go
@@ -1,0 +1,22 @@
+// +build !go1.7
+
+package sessions
+
+import (
+	"net/http"
+
+	"github.com/gorilla/context"
+)
+
+func contextGet(r *http.Request, key contextKey) interface{} {
+	return context.Get(r, key)
+}
+
+func contextSave(r *http.Request, key contextKey, val interface{}) *http.Request {
+	context.Set(r, key, val)
+	return r
+}
+
+func contextClear(r *http.Request) {
+	context.Clear(r)
+}

--- a/store.go
+++ b/store.go
@@ -77,7 +77,9 @@ type CookieStore struct {
 // It returns a new session and an error if the session exists but could
 // not be decoded.
 func (s *CookieStore) Get(r *http.Request, name string) (*Session, error) {
-	return GetRegistry(r).Get(s, name)
+	reg, req := GetRegistry(r)
+	*r = *req
+	return reg.Get(s, name)
 }
 
 // New returns a session for the given name without adding it to the registry.
@@ -180,7 +182,9 @@ func (s *FilesystemStore) MaxLength(l int) {
 //
 // See CookieStore.Get().
 func (s *FilesystemStore) Get(r *http.Request, name string) (*Session, error) {
-	return GetRegistry(r).Get(s, name)
+	reg, req := GetRegistry(r)
+	*r = *req
+	return reg.Get(s, name)
 }
 
 // New returns a session for the given name without adding it to the registry.


### PR DESCRIPTION
Tests on Go 1.7 currently failing with:

```
➜  sessions [go17-context] go test
--- FAIL: TestFlashes (0.00s)
    sessions_test.go:71: No cookies. Header: map[]
FAIL
exit status 1
FAIL    github.com/gorilla/sessions 0.014s
```

Trying to debug. cc @elithrar 
