### PR TITLE
[docs] Add Store Implementations Project Link - MySQL Cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Other implementations of the `sessions.Store` interface:
 * [github.com/dsoprea/go-appengine-sessioncascade](https://github.com/dsoprea/go-appengine-sessioncascade) - Memcache/Datastore/Context in AppEngine
 * [github.com/kidstuff/mongostore](https://github.com/kidstuff/mongostore) - MongoDB
 * [github.com/srinathgs/mysqlstore](https://github.com/srinathgs/mysqlstore) - MySQL
+* [github.com/EnumApps/clustersqlstore](https://github.com/EnumApps/clustersqlstore) - MySQL Cluster
 * [github.com/antonlindstrom/pgstore](https://github.com/antonlindstrom/pgstore) - PostgreSQL
 * [github.com/boj/redistore](https://github.com/boj/redistore) - Redis
 * [github.com/boj/rethinkstore](https://github.com/boj/rethinkstore) - RethinkDB


### PR DESCRIPTION
a new store implementation is published, and wish to add the link to ReadME

https://github.com/EnumApps/clustersqlstore

p.s. the store passed unit test