### PR TITLE
Fix MaxAge check.

### DIFF
--- a/store.go
+++ b/store.go
@@ -206,14 +206,14 @@ func (s *FilesystemStore) New(r *http.Request, name string) (*Session, error) {
 
 // Save adds a single session to the response.
 //
-// If the Options.MaxAge of the session is <= 0 then the session file will be
+// If the Options.MaxAge of the session is < 0 then the session file will be
 // deleted from the store path. With this process it enforces the properly
 // session cookie handling so no need to trust in the cookie management in the
 // web browser.
 func (s *FilesystemStore) Save(r *http.Request, w http.ResponseWriter,
 	session *Session) error {
-	// Delete if max-age is <= 0
-	if session.Options.MaxAge <= 0 {
+	// Delete if max-age is < 0
+	if session.Options.MaxAge < 0 {
 		if err := s.erase(session); err != nil {
 			return err
 		}

--- a/store_test.go
+++ b/store_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -96,6 +98,11 @@ func TestGH8FilesystemStoreDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to delete session", err)
 	}
+
+	path := filepath.Join(os.TempDir(), "session_"+session.ID)
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("failed to delete file: %s", path)
+	}
 }
 
 // Test delete filesystem store with max-age: 0
@@ -121,5 +128,10 @@ func TestGH8FilesystemStoreDelete2(t *testing.T) {
 	err = session.Save(req, w)
 	if err != nil {
 		t.Fatal("failed to delete session", err)
+	}
+
+	path := filepath.Join(os.TempDir(), "session_"+session.ID)
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Fatalf("failed to preserve file: %s", path)
 	}
 }


### PR DESCRIPTION
Since `MaxAge` of 0 means cookies shouldn't be expired, only delete cookies with `MaxAge < 0`. Plus, update tests to verify that session files have been deleted or not, as appropriate.

[Resolves #96]

cc @adborden