### PR TITLE
Add missing ClearHandler example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ with
 as or else you will leak memory! An easy way to do this is to wrap the top-level
 mux when calling http.ListenAndServe:
 
+```go
+	http.ListenAndServe(":8080", context.ClearHandler(http.DefaultServeMux))
+```
+
+The ClearHandler function is provided by the gorilla/context package.
+
 More examples are available [on the Gorilla
 website](http://www.gorillatoolkit.org/pkg/sessions).
 


### PR DESCRIPTION
The current README stops short at a colon where it looks like it should have a code example.

I copied the example in the same section from `doc.go`.