### PR TITLE
Add link to memstore implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Other implementations of the `sessions.Store` interface:
 * [github.com/michaeljs1990/sqlitestore](https://github.com/michaeljs1990/sqlitestore) - SQLite
 * [github.com/wader/gormstore](https://github.com/wader/gormstore) - GORM (MySQL, PostgreSQL, SQLite)
 * [github.com/gernest/qlstore](https://github.com/gernest/qlstore) - ql
+* [github.com/quasoft/memstore](https://github.com/quasoft/memstore) - In-memory implementation for use in unit tests
 
 ## License
 


### PR DESCRIPTION
Adds a link to memstore, an in-memory implementation of `sessions.Store` for use in unit tests