### PR TITLE
Adds support for SameSite cookie attribute

### DIFF
--- a/options.go
+++ b/options.go
@@ -1,0 +1,18 @@
+// +build !go1.11
+
+package sessions
+
+// Options stores configuration for a session or session store.
+//
+// Fields are a subset of http.Cookie fields.
+type Options struct {
+	Path   string
+	Domain string
+	// MaxAge=0 means no Max-Age attribute specified and the cookie will be
+	// deleted after the browser session ends.
+	// MaxAge<0 means delete cookie immediately.
+	// MaxAge>0 means Max-Age attribute present and given in seconds.
+	MaxAge   int
+	Secure   bool
+	HttpOnly bool
+}

--- a/options_go111.go
+++ b/options_go111.go
@@ -1,0 +1,22 @@
+// +build go1.11
+
+package sessions
+
+import "net/http"
+
+// Options stores configuration for a session or session store.
+//
+// Fields are a subset of http.Cookie fields.
+type Options struct {
+	Path   string
+	Domain string
+	// MaxAge=0 means no Max-Age attribute specified and the cookie will be
+	// deleted after the browser session ends.
+	// MaxAge<0 means delete cookie immediately.
+	// MaxAge>0 means Max-Age attribute present and given in seconds.
+	MaxAge   int
+	Secure   bool
+	HttpOnly bool
+	// Defaults to http.SameSiteDefaultMode
+	SameSite http.SameSite
+}

--- a/sessions.go
+++ b/sessions.go
@@ -16,23 +16,6 @@ import (
 // Default flashes key.
 const flashesKey = "_flash"
 
-// Options --------------------------------------------------------------------
-
-// Options stores configuration for a session or session store.
-//
-// Fields are a subset of http.Cookie fields.
-type Options struct {
-	Path   string
-	Domain string
-	// MaxAge=0 means no Max-Age attribute specified and the cookie will be
-	// deleted after the browser session ends.
-	// MaxAge<0 means delete cookie immediately.
-	// MaxAge>0 means Max-Age attribute present and given in seconds.
-	MaxAge   int
-	Secure   bool
-	HttpOnly bool
-}
-
 // Session --------------------------------------------------------------------
 
 // NewSession is called by session stores to create a new session instance.


### PR DESCRIPTION
Addresses #164 

Adds support for the [`SameSite`](https://golang.org/pkg/net/http/#SameSite) attribute introduced in Go 1.11 - a new cookie attribute introduced to further prevent CSRF attacks: https://blog.mozilla.org/security/2018/04/24/same-site-cookies-in-firefox-60/