### PR TITLE
Update documentation to reflect gorilla/mux change

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ secret key used to authenticate the session. Inside the handler, we call
 some session values in session.Values, which is a `map[interface{}]interface{}`.
 And finally we call `session.Save()` to save the session in the response.
 
-Important Note: If you aren't using gorilla/mux, you need to wrap your handlers
-with
+Important Note: You need to wrap your handlers with
 [`context.ClearHandler`](https://www.gorillatoolkit.org/pkg/context#ClearHandler)
 or else you will leak memory! An easy way to do this is to wrap the top-level
 mux when calling http.ListenAndServe:

--- a/doc.go
+++ b/doc.go
@@ -59,9 +59,9 @@ session.Save(r, w), and either display an error message or otherwise handle it.
 Save must be called before writing to the response, otherwise the session
 cookie will not be sent to the client.
 
-Important Note: If you aren't using gorilla/mux, you need to wrap your handlers
-with context.ClearHandler as or else you will leak memory! An easy way to do this
-is to wrap the top-level mux when calling http.ListenAndServe:
+Important Note: You need to wrap your handlers with context.ClearHandler as
+or else you will leak memory! An easy way to do this is to wrap the top-level
+mux when calling http.ListenAndServe:
 
     http.ListenAndServe(":8080", context.ClearHandler(http.DefaultServeMux))
 


### PR DESCRIPTION
gorilla/mux no longer automatically clears gorilla/context between requests as it now uses the request context instead. This gotcha means that even when using gorilla/mux, handlers must be wrapped in ClearHandler or memory leaks will occur.