### PR TITLE
remove context dependency since it's been removed from code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,5 @@
 module github.com/gorilla/sessions
 
 require (
-	github.com/gorilla/context v1.1.1
 	github.com/gorilla/securecookie v1.1.1
 )

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/gorilla/sessions
 
-require (
-	github.com/gorilla/securecookie v1.1.1
-)
+require github.com/gorilla/securecookie v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
+github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=


### PR DESCRIPTION
Since https://github.com/gorilla/sessions/commit/12bd4761fc66ac946e16fcc2a32b1e0b066f6177 the `gorilla/context` package is no longer used in this package.  This change removes it from the list of required packages for dependency management.