### PR TITLE
Remove gorilla/context from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gorilla/sessions
 
 require (
-	github.com/gorilla/context v1.1.1
+	//github.com/gorilla/context v1.1.1
 	github.com/gorilla/securecookie v1.1.1
 )


### PR DESCRIPTION
I suggest removing gorilla/context from the requirements in go.mod since this package is 
already using the standard context package found in the standard library. Also, gorilla/context is no longer 
present in any import.