### PR TITLE
Added _ = to indicate there is a return from Save

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Let's start with an example that shows the sessions API in a nutshell:
 		session.Values["foo"] = "bar"
 		session.Values[42] = 43
 		// Save it before we write to the response/return from the handler.
-		session.Save(r, w)
+		_ = session.Save(r, w)
 	}
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ Let's start with an example that shows the sessions API in a nutshell:
 		session.Values["foo"] = "bar"
 		session.Values[42] = 43
 		// Save it before we write to the response/return from the handler.
-		_ = session.Save(r, w)
+		err = session.Save(r, w)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 ```
 

--- a/doc.go
+++ b/doc.go
@@ -30,6 +30,7 @@ Let's start with an example that shows the sessions API in a nutshell:
 	// environmental variable, or flag (or both), and don't accidentally commit it
 	// alongside your code. Ensure your key is sufficiently random - i.e. use Go's
 	// crypto/rand or securecookie.GenerateRandomKey(32) and persist the result.
+	// Ensure SESSION_KEY exists in the environment, or sessions will fail.
 	var store = sessions.NewCookieStore(os.Getenv("SESSION_KEY"))
 
 	func MyHandler(w http.ResponseWriter, r *http.Request) {
@@ -44,7 +45,11 @@ Let's start with an example that shows the sessions API in a nutshell:
 		session.Values["foo"] = "bar"
 		session.Values[42] = 43
 		// Save it before we write to the response/return from the handler.
-		session.Save(r, w)
+		err = session.Save(r, w)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 
 First we initialize a session store calling NewCookieStore() and passing a
@@ -82,7 +87,11 @@ flashes, call session.Flashes(). Here is an example:
 			// Set a new flash.
 			session.AddFlash("Hello, flash messages world!")
 		}
-		session.Save(r, w)
+		err = session.Save(r, w)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 
 Flash messages are useful to set information to be read after a redirection,
@@ -185,7 +194,11 @@ at once: it's sessions.Save(). Here's an example:
 		session2, _ := store.Get(r, "session-two")
 		session2.Values[42] = 43
 		// Save all sessions.
-		sessions.Save(r, w)
+		err = sessions.Save(r, w)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 
 This is possible because when we call Get() from a session store, it adds the


### PR DESCRIPTION
This is because I copied the sample and failed to notice there was a return, which for me was failing, and lost a bunch of time to troubleshooting. (Note: I actually copied the samples from here - https://www.gorillatoolkit.org/pkg/sessions - but don't know how to update that page.)

Fixes #

**Summary of Changes**

1. Added _ = 'cos even though the error is ignored this shows one exists
2. 
3.

> PS: Make sure your PR includes/updates tests! If you need help with this part, just ask!
