### PR TITLE
Removed unused global var

### DIFF
--- a/sessions_test.go
+++ b/sessions_test.go
@@ -20,10 +20,6 @@ func NewRecorder() *httptest.ResponseRecorder {
 	}
 }
 
-// DefaultRemoteAddr is the default remote address to return in RemoteAddr if
-// an explicit DefaultRemoteAddr isn't set on ResponseRecorder.
-const DefaultRemoteAddr = "1.2.3.4"
-
 // ----------------------------------------------------------------------------
 
 type FlashMessage struct {


### PR DESCRIPTION
DefaultRemoteAddr seems to not be used (any longer?).