### PR TITLE
README.md: link Cloud Firestore implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Other implementations of the `sessions.Store` interface:
 - [github.com/gernest/qlstore](https://github.com/gernest/qlstore) - ql
 - [github.com/quasoft/memstore](https://github.com/quasoft/memstore) - In-memory implementation for use in unit tests
 - [github.com/lafriks/xormstore](https://github.com/lafriks/xormstore) - XORM (MySQL, PostgreSQL, SQLite, Microsoft SQL Server, TiDB)
+- [github.com/GoogleCloudPlatform/firestore-gorilla-sessions](https://github.com/GoogleCloudPlatform/firestore-gorilla-sessions) - Cloud Firestore
 
 ## License
 


### PR DESCRIPTION
I wrote a `Store` implementation backed by Cloud Firestore: https://github.com/GoogleCloudPlatform/firestore-gorilla-sessions.