### PR TITLE
Add Redis store implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Other implementations of the `sessions.Store` interface:
 - [github.com/EnumApps/clustersqlstore](https://github.com/EnumApps/clustersqlstore) - MySQL Cluster
 - [github.com/antonlindstrom/pgstore](https://github.com/antonlindstrom/pgstore) - PostgreSQL
 - [github.com/boj/redistore](https://github.com/boj/redistore) - Redis
+- [github.com/rbcervilla/redisstore](https://github.com/rbcervilla/redisstore) - Redis (Single, Sentinel, Cluster)
 - [github.com/boj/rethinkstore](https://github.com/boj/rethinkstore) - RethinkDB
 - [github.com/boj/riakstore](https://github.com/boj/riakstore) - Riak
 - [github.com/michaeljs1990/sqlitestore](https://github.com/michaeljs1990/sqlitestore) - SQLite


### PR DESCRIPTION
**Added Redis store implementation**

1. Redis store implementation with [go-redis](https://github.com/go-redis/redis) as Redis client. This enables use Redis on single mode, Sentinel and Cluster.


