### PR TITLE
FileStorage erase session fix

### DIFF
--- a/store.go
+++ b/store.go
@@ -211,7 +211,7 @@ func (s *FilesystemStore) Save(r *http.Request, w http.ResponseWriter,
 	session *Session) error {
 	// Delete if max-age is <= 0
 	if session.Options.MaxAge <= 0 {
-		if err := s.erase(session); err != nil {
+		if err := s.erase(session); err != nil && !os.IsNotExist(err) {
 			return err
 		}
 		http.SetCookie(w, NewCookie(session.Name(), "", session.Options))


### PR DESCRIPTION
**Summary of Changes**

Don't consider "oserror.ErrNotExist" as a failure when trying to erase a session which corresponds to a missing file.

___

Hello, in the current implementation if a request contains a session token that has been stored in a file that has been deleted the and we're trying to erase it using the `Options.MaxAge = -1` workaround, the action still fails, because the missing file error gets propagated higher in the stack. 

This small fix prevents this, and ensures that the session is regenerated.

Please let me know if you have any feedback. Having this merged would help tremendously with one of the projects I'm working on.