### PR TITLE
Stopped outdated error from being returned

### DIFF
--- a/cookie.go
+++ b/cookie.go
@@ -1,3 +1,4 @@
+//go:build !go1.11
 // +build !go1.11
 
 package sessions

--- a/cookie_go111.go
+++ b/cookie_go111.go
@@ -1,3 +1,4 @@
+//go:build go1.11
 // +build go1.11
 
 package sessions

--- a/cookie_go111_test.go
+++ b/cookie_go111_test.go
@@ -1,3 +1,4 @@
+//go:build go1.11
 // +build go1.11
 
 package sessions

--- a/options.go
+++ b/options.go
@@ -1,3 +1,4 @@
+//go:build !go1.11
 // +build !go1.11
 
 package sessions

--- a/options_go111.go
+++ b/options_go111.go
@@ -1,3 +1,4 @@
+//go:build go1.11
 // +build go1.11
 
 package sessions

--- a/sessions.go
+++ b/sessions.go
@@ -133,7 +133,7 @@ func (s *Registry) Get(store Store, name string) (session *Session, err error) {
 		return nil, fmt.Errorf("sessions: invalid character in cookie name: %s", name)
 	}
 	if info, ok := s.sessions[name]; ok {
-		session = info.Session
+		session, err = info.Session, nil
 	} else {
 		session, err = store.New(s.request, name)
 		if err != nil {

--- a/sessions.go
+++ b/sessions.go
@@ -136,9 +136,6 @@ func (s *Registry) Get(store Store, name string) (session *Session, err error) {
 		session, err = info.Session, nil
 	} else {
 		session, err = store.New(s.request, name)
-		if err != nil {
-			return
-		}
 		session.name = name
 		s.sessions[name] = sessionInfo{session}
 	}


### PR DESCRIPTION
Fixes #249

**Summary of Changes**

1. Internal change to make it so that if there is an error while creating a session the session won't be saved to the registry.
2. Fixed an issue which would cause a nil pointer dereference
3. Note: This does not change anything for the users utilizing the library apart from the fact that certain kinds of errors won't happen anymore

This didn't need any test changes.