### PR TITLE
Fix linting errors for go1.17

### DIFF
--- a/cookie.go
+++ b/cookie.go
@@ -1,3 +1,4 @@
+//go:build !go1.11
 // +build !go1.11
 
 package sessions

--- a/cookie_go111.go
+++ b/cookie_go111.go
@@ -1,3 +1,4 @@
+//go:build go1.11
 // +build go1.11
 
 package sessions

--- a/cookie_go111_test.go
+++ b/cookie_go111_test.go
@@ -1,3 +1,4 @@
+//go:build go1.11
 // +build go1.11
 
 package sessions

--- a/options.go
+++ b/options.go
@@ -1,3 +1,4 @@
+//go:build !go1.11
 // +build !go1.11
 
 package sessions

--- a/options_go111.go
+++ b/options_go111.go
@@ -1,3 +1,4 @@
+//go:build go1.11
 // +build go1.11
 
 package sessions


### PR DESCRIPTION
Summary of Changes

The CI step that lints the package using latest go version (1.17) fails due to the introduction of new `//go:build ` directives.

This adds them so gofmt doesn't report any differences.