### PR TITLE
Add methods to choose the correct session cookie

### DIFF
--- a/cookie.go
+++ b/cookie.go
@@ -1,3 +1,4 @@
+//go:build !go1.11
 // +build !go1.11
 
 package sessions

--- a/cookie_go111.go
+++ b/cookie_go111.go
@@ -1,3 +1,4 @@
+//go:build go1.11
 // +build go1.11
 
 package sessions

--- a/cookie_go111_test.go
+++ b/cookie_go111_test.go
@@ -1,3 +1,4 @@
+//go:build go1.11
 // +build go1.11
 
 package sessions

--- a/doc.go
+++ b/doc.go
@@ -203,5 +203,29 @@ at once: it's sessions.Save(). Here's an example:
 
 This is possible because when we call Get() from a session store, it adds the
 session to a common registry. Save() uses it to save all registered sessions.
+
+Sometimes it may happen that an HTTP request includes two cookies of the same
+name. This will usually happen when `sessions.Save` is called twice. To handle
+these situations gracefully, you can use the `GetExact` method to find an exact
+match for your cookie. Please note that the store must implement the StoreExact
+interface for this to work. All default store implementations in this repository
+implement StoreExact.
+
+	var store = sessions.NewCookieStore([]byte("something-very-secret"))
+
+	func MyHandler(w http.ResponseWriter, r *http.Request) {
+		// Get a session and set a value.
+		session1, _ := store.GetExact(r, "session-one", func(s *sessions.Session) {
+			// Only reuse cookies that match "foo" value of "baz".
+			return s.Values["foo"] == "baz"
+		})
+		session1.Values["foo"] = "bar"
+		// Save sessions.
+		err = sessions.Save(r, w)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
 */
 package sessions

--- a/matcher.go
+++ b/matcher.go
@@ -1,0 +1,10 @@
+package sessions
+
+// Matcher defines a function used to identify the correct session and cookie
+// for a request which contains multiple session cookies of the same name.
+type Matcher func(session *Session) bool
+
+// FirstMatcher returns instructs to use the first session and cookie of a given request
+func FirstMatcher(_ *Session) bool {
+	return true
+}

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -1,0 +1,9 @@
+package sessions
+
+import "testing"
+
+func TestFirstMatcher(t *testing.T) {
+	if !FirstMatcher(nil) {
+		t.Error("First matcher should match first session")
+	}
+}

--- a/options.go
+++ b/options.go
@@ -1,3 +1,4 @@
+//go:build !go1.11
 // +build !go1.11
 
 package sessions

--- a/options_go111.go
+++ b/options_go111.go
@@ -1,3 +1,4 @@
+//go:build go1.11
 // +build go1.11
 
 package sessions


### PR DESCRIPTION
Sometimes it can happen that a browser has two cookies for with the same name. This might be the case where developers forget to enforce a `path` variable or the `domain` attribute or accidentally call `Set-Cookie` twice. In those cases, this library would previously return whatever cookie  `r.Cookie(name)` would return.

This patch introduces a new function called `GetExact` which allows one to pass a filter function which receives the `Session` attribute. That way, there is a way to search for a specific session if multiple session have been found.

This functional change is fully backwards compatible by introducing a new interface `StoreExact` which defines what a store needs to implement to conform to this new logic. Stores which do not have these new methods will fallback to the previous behavior, were the first cookie found will be used.

All default stores in this library already implement the `StoreExact` method with this patch.

In particular, this issue has affected our open source projects at [Ory](https://github.com/ory) quite heavily. The changes in this patch will contribute towards making these type of errors easier to deal with!