### PR TITLE
Fixes scope issue in retrieval and type-assert sample

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -139,8 +139,8 @@ a need to type-assert data when retrieving it. We'll use the Person struct we re
 
 		// Retrieve our struct and type-assert it
 		val := session.Values["person"]
-		var person = &Person{}
-		if person, ok := val.(*Person); !ok {
+		person, ok := val.(*Person)
+		if !ok {
 			// Handle the case that it's not an expected type
 		}
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure that you have:
     - [x] Read the Contributing guide: https://github.com/gorilla/.github/blob/main/CONTRIBUTING.md
     - [x] Read the Code of Conduct: https://github.com/gorilla/.github/blob/main/CODE_OF_CONDUCT.md

     - Provide tests for your changes.
     - Use descriptive commit messages.
	 - Comment your code where appropriate.
	 - Squash your commits
     - Update any related documentation.

     - Add gorilla/pull-request-reviewers as a Reviewer
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Go Version Update
- [ ] Dependency Update

## Description

The code sample for retrieval and type-assertion of a stored value did not assign the retrieved value to the var.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue  #283
- Closes # 283

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: documentation only
- [ ] I need help with writing tests

## Run verifications and test

- [x] `make verify` is passing
- [x] `make test` is passing
